### PR TITLE
Adding Protect AI Modelscan to Model Testing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _Products that examine or test models for security issues of various kinds._
 * [Adversa Red Teaming](https://adversa.ai/ai-red-teaming-llm/) - Continuous AI red teaming for LLMs
 * [Advai](https://www.advai.co.uk) - Automates the tasks of stress-testing, red-teaming, and evaluating your AI systems for critical failure
 * [Mindgard AI](https://mindgard.ai) - Identifies and remediates risks across AI models, GenAI, LLMs along with AI-powered apps and chatbots
+* [Protect AI ModelScan](https://github.com/protectai/modelscan) - Scan models for serialization attacks [![code](https://img.shields.io/github/license/protectai/modelscan)]
 * [Protect AI Guardian](https://protectai.com/guardian) - Scan models for security issues or policy violations with auditing and reporting
 
 ## Prompt Firewall and Redaction


### PR DESCRIPTION
Adding Protect AI Modelscan to Model Testing category

Also here's the updated image, not sure how to cut a PR of it without a complex fork.

![awesome-ai-security-infographic](https://github.com/zmre/awesome-security-for-ai/assets/82452/4e25879d-5172-46c1-a31e-97a90202bb48)
